### PR TITLE
Support for fully-qualified URLs as paths

### DIFF
--- a/Imgix.xcodeproj/project.pbxproj
+++ b/Imgix.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		21EB0C941B10074F00CDC863 /* Imgix.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 21EB0C881B10074F00CDC863 /* Imgix.framework */; };
 		21EB0CA61B100A9E00CDC863 /* IGXClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 21EB0CA41B100A9E00CDC863 /* IGXClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		21EB0CA71B100A9E00CDC863 /* IGXClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 21EB0CA51B100A9E00CDC863 /* IGXClient.m */; };
+		A25F62D71B1265D800A16FF4 /* PathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A25F62D61B1265D800A16FF4 /* PathTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		21EB0C931B10074F00CDC863 /* ImgixTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ImgixTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		21EB0CA41B100A9E00CDC863 /* IGXClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGXClient.h; sourceTree = "<group>"; };
 		21EB0CA51B100A9E00CDC863 /* IGXClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGXClient.m; sourceTree = "<group>"; };
+		A25F62D61B1265D800A16FF4 /* PathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PathTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +114,7 @@
 				21B109951B10DC6200C7738C /* AdjustmentTests.m */,
 				21BAB1271B11078100D32A0C /* BackgroundTests.m */,
 				21BAB1291B11078900D32A0C /* FormatTests.m */,
+				A25F62D61B1265D800A16FF4 /* PathTests.m */,
 				21BAB12B1B11079200D32A0C /* PDFTests.m */,
 				214FC3F31B1139A500B04DDF /* StylizeTests.m */,
 				21B1097F1B10CC1600C7738C /* Info.plist */,
@@ -333,6 +336,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				21BAB12A1B11078900D32A0C /* FormatTests.m in Sources */,
+				A25F62D71B1265D800A16FF4 /* PathTests.m in Sources */,
 				214FC3F41B1139A500B04DDF /* StylizeTests.m in Sources */,
 				21BAB12C1B11079200D32A0C /* PDFTests.m in Sources */,
 				21B109961B10DC6200C7738C /* AdjustmentTests.m in Sources */,

--- a/Imgix/IGXClient.m
+++ b/Imgix/IGXClient.m
@@ -78,6 +78,11 @@
 - (igx_nullable NSURL *)URLWithPath:(igx_nonnull NSString *)path {
 	NSString *scheme = self.secure ? @"https" : @"http";
 
+    if ([path hasPrefix:@"http"]) {
+        path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+        path = [path stringByReplacingOccurrencesOfString:@"=" withString:@"%3D"];
+    }
+
 	if (![path hasPrefix:@"/"]) {
 		path = [@"/" stringByAppendingString:path];
 	}

--- a/Tests/PathTests.m
+++ b/Tests/PathTests.m
@@ -1,0 +1,33 @@
+//
+//  PathTests.m
+//  Imgix
+//
+//  Created by Kelly Sutton on 5/23/15.
+//  Copyright (c) 2015 Sam Soffes. All rights reserved.
+//
+
+#import "TestHelper.h"
+
+@interface PathTests : TestCase
+@end
+
+@implementation PathTests
+
+- (void)testPathForWebFolderAndS3BucketSources {
+    XCTAssertEqualObjects(@"https://nothingmagical.imgix.net/sam.jpg", [self.client URLWithPath:@"sam.jpg"].absoluteString);
+}
+
+- (void)testPathForWebFolderAndS3BucketSourcesWithSlashPrefix {
+    XCTAssertEqualObjects(@"https://nothingmagical.imgix.net/sam.jpg", [self.client URLWithPath:@"/sam.jpg"].absoluteString);
+}
+
+- (void)testFullyQualifiedURLAsPathComponent {
+    XCTAssertEqualObjects(@"https://nothingmagical.imgix.net/https%3A%2F%2Fexample.com%2Fsome-example-image.jpg", [self.client URLWithPath:@"https://example.com/some-example-image.jpg"].absoluteString);
+}
+
+- (void)testFullyQualifiedURLWithQueryParamsAsPathComponent {
+    XCTAssertEqualObjects(@"https://nothingmagical.imgix.net/https%3A%2F%2Fexample.com%2Fsome-example-image.jpg%3Futm_source%3Dtwitter", [self.client URLWithPath:@"https://example.com/some-example-image.jpg?utm_source=twitter"].absoluteString);
+}
+
+
+@end


### PR DESCRIPTION
It's a common imgix gotcha to not encode fully-qualified URLs when using a Web Proxy source. See the bottom section of http://www.imgix.com/docs/tutorials/creating-sources for more info on Web Proxy sources.

This code is little gross for a few reasons:
- It's using a double-pass string replacement to properly encode the URL, due to deficiencies in `stringByAddingPercentEncodingWithAllowedCharacters` when using the `URLHostAllowedCharacterSet`. Equal signs are not encoded into `%3D` correctly.
- It will break if another web protocol should come along that is not prefixed with `http`.

What's a better way of accomplishing this?
